### PR TITLE
[SSB-3] Add service package

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -3,14 +3,16 @@
   <component name="ChangeListManager">
     <list default="true" id="81a9836d-c4fb-4988-b45f-3395bd09ef6c" name="Default Changelist" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Makefile" beforeDir="false" afterPath="$PROJECT_DIR$/Makefile" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/cmd/api/controller/controller.go" beforeDir="false" afterPath="$PROJECT_DIR$/cmd/api/controller/controller.go" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/cmd/api/controller/suggest.go" beforeDir="false" afterPath="$PROJECT_DIR$/cmd/api/controller/suggest.go" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/cmd/api/model/superhero.go" beforeDir="false" afterPath="$PROJECT_DIR$/cmd/api/model/superhero.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/cmd/api/model/request.go" beforeDir="false" afterPath="$PROJECT_DIR$/cmd/api/model/request.go" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/config.yml" beforeDir="false" afterPath="$PROJECT_DIR$/config.yml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/internal/config/config.go" beforeDir="false" afterPath="$PROJECT_DIR$/internal/config/config.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/internal/config/app.go" beforeDir="false" afterPath="$PROJECT_DIR$/internal/config/app.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/internal/config/es.go" beforeDir="false" afterPath="$PROJECT_DIR$/internal/config/es.go" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/internal/es/es.go" beforeDir="false" afterPath="$PROJECT_DIR$/internal/es/es.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/internal/es/model/request.go" beforeDir="false" afterPath="$PROJECT_DIR$/internal/es/model/request.go" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/internal/es/model/superhero.go" beforeDir="false" afterPath="$PROJECT_DIR$/internal/es/model/superhero.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/internal/es/suggestion.go" beforeDir="false" afterPath="$PROJECT_DIR$/internal/es/suggestion.go" afterDir="false" />
     </list>
     <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
     <option name="SHOW_DIALOG" value="false" />
@@ -50,6 +52,7 @@
   </component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
+      <recent name="C:\Users\ACER\go\src\github.com\superhero-suggestions\cmd\api\controller\service" />
       <recent name="C:\Users\ACER\go\src\github.com\superhero-suggestions" />
     </key>
   </component>

--- a/cmd/api/controller/controller.go
+++ b/cmd/api/controller/controller.go
@@ -3,41 +3,29 @@ package controller
 import (
 	"github.com/gin-gonic/gin"
 
-	"github.com/superhero-suggestions/internal/cache"
+	"github.com/superhero-suggestions/cmd/api/controller/service"
 	"github.com/superhero-suggestions/internal/config"
-	"github.com/superhero-suggestions/internal/es"
 )
 
-// Controller contains definition of controller methods.
-type Controller interface {
-	RegisterRoutes() *gin.Engine
-}
-
-type controller struct {
-	ES    *es.ES
-	Cache *cache.Cache
+// Controller holds the Controller data.
+type Controller struct {
+	Service *service.Service
 }
 
 // NewController returns new controller.
-func NewController(cfg *config.Config) (ctrl Controller, err error) {
-	e, err := es.NewES(cfg)
+func NewController(cfg *config.Config) (*Controller, error) {
+	srv, err := service.NewService(cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	c, err := cache.NewCache(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	return &controller{
-		ES:    e,
-		Cache: c,
+	return &Controller{
+		Service: srv,
 	}, nil
 }
 
 // RegisterRoutes registers all the superhero_suggestions API routes.
-func (ctl *controller) RegisterRoutes() *gin.Engine {
+func (ctl *Controller) RegisterRoutes() *gin.Engine {
 	router := gin.Default()
 
 	sr := router.Group("/api/v1/superhero_suggestions")

--- a/cmd/api/controller/service/api.go
+++ b/cmd/api/controller/service/api.go
@@ -1,0 +1,27 @@
+package service
+
+import (
+	"github.com/superhero-suggestions/cmd/api/controller/service/mapper"
+	ctrl "github.com/superhero-suggestions/cmd/api/model"
+)
+
+// HandleESRequest fetches suggestions from Elasticsearch,
+// then caches them and returns page size of results.
+func (srv *Service) HandleESRequest(req ctrl.Request) (suggestions []ctrl.Superhero, esSuperheroIDs []string, err error) {
+	superheros, err := srv.GetESSuggestions(req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result, esSuperheroIDs := mapper.MapESSuggestionsToResult(superheros)
+
+	err = srv.CacheSuggestions(result)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Return max 10 suggestions.
+	suggestions = mapper.CutTotalResultToPageSize(srv.PageSize, result)
+
+	return suggestions, esSuperheroIDs, nil
+}

--- a/cmd/api/controller/service/cache.go
+++ b/cmd/api/controller/service/cache.go
@@ -1,0 +1,23 @@
+package service
+
+import (
+	"strings"
+
+	"github.com/superhero-suggestions/cmd/api/controller/service/mapper"
+	"github.com/superhero-suggestions/cmd/api/model"
+)
+
+// GetCachedSuggestions fetches suggestions from cache and maps them into result.
+func (srv *Service) GetCachedSuggestions(req model.Request) (result []model.Superhero, err error) {
+	cachedSuggestions, err := srv.Cache.GetSuggestions(strings.Join(req.SuperheroIDs, ","))
+	if err != nil {
+		return nil, err
+	}
+
+	return mapper.MapCacheSuggestionsToResult(cachedSuggestions), nil
+}
+
+// CacheSuggestions maps ES models to Cache models and caches the suggestions.
+func (srv *Service) CacheSuggestions(result []model.Superhero) error {
+	return srv.Cache.SetSuggestions(mapper.MapResultToCacheSuggestions(result))
+}

--- a/cmd/api/controller/service/es.go
+++ b/cmd/api/controller/service/es.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	ctrl "github.com/superhero-suggestions/cmd/api/model"
+	"github.com/superhero-suggestions/internal/es/model"
+)
+
+// GetESSuggestions fetches suggestions from Elasticsearch.
+func (srv *Service) GetESSuggestions(req ctrl.Request) (superheros []model.Superhero, err error) {
+	superheros, err = srv.ES.GetSuggestions(
+		&model.Request{
+			ID:               req.ID,
+			LookingForGender: req.LookingForGender,
+			Gender:           req.Gender,
+			LookingForAgeMin: req.LookingForAgeMin,
+			LookingForAgeMax: req.LookingForAgeMax,
+			MaxDistance:      req.MaxDistance,
+			DistanceUnit:     req.DistanceUnit,
+			Lat:              req.Lat,
+			Lon:              req.Lon,
+			SuperheroIDs:     req.SuperheroIDs,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return superheros, nil
+}

--- a/cmd/api/controller/service/mapper/api.go
+++ b/cmd/api/controller/service/mapper/api.go
@@ -1,0 +1,57 @@
+package mapper
+
+import (
+	"github.com/superhero-suggestions/cmd/api/model"
+	es "github.com/superhero-suggestions/internal/es/model"
+)
+
+// CutTotalResultToPageSize takes only specified page size, default is 10, or less from total result set.
+func CutTotalResultToPageSize(pageSize int, totalResult []model.Superhero) (suggestions []model.Superhero) {
+	for _, suggestion := range totalResult {
+		if pageSize == int(0) {
+			break
+		}
+
+		suggestions = append(suggestions, suggestion)
+
+		pageSize--
+	}
+
+	return suggestions
+}
+
+// MapESSuggestionsToResult maps ES Superhero to result Superhero.
+func MapESSuggestionsToResult(superheros []es.Superhero) (result []model.Superhero, esSuperheroIDs []string) {
+	for _, s := range superheros {
+		esSuperheroIDs = append(esSuperheroIDs, s.ID)
+
+		superhero := model.Superhero{
+			ID:                s.ID,
+			SuperheroName:     s.SuperheroName,
+			MainProfilePicURL: s.MainProfilePicURL,
+			Gender:            s.Gender,
+			Age:               s.Age,
+			Lat:               s.Location.Lat,
+			Lon:               s.Location.Lon,
+			Birthday:          s.Birthday,
+			Country:           s.Country,
+			City:              s.City,
+			SuperPower:        s.SuperPower,
+			AccountType:       s.AccountType,
+			CreatedAt:         s.CreatedAt,
+		}
+
+		for _, profilePicture := range s.ProfilePictures {
+			superhero.ProfilePictures = append(superhero.ProfilePictures, model.ProfilePicture{
+				ID:                profilePicture.ID,
+				SuperheroID:       profilePicture.SuperheroID,
+				ProfilePictureURL: profilePicture.ProfilePictureURL,
+				Position:          profilePicture.Position,
+			})
+		}
+
+		result = append(result, superhero)
+	}
+
+	return result, esSuperheroIDs
+}

--- a/cmd/api/controller/service/mapper/cache.go
+++ b/cmd/api/controller/service/mapper/cache.go
@@ -1,0 +1,74 @@
+package mapper
+
+import (
+	"github.com/superhero-suggestions/cmd/api/model"
+	cache "github.com/superhero-suggestions/internal/cache/model"
+)
+
+// MapCacheSuggestionsToResult maps cache Superhero models to API models that are returned to the user.
+func MapCacheSuggestionsToResult(cachedSuggestions []cache.Superhero) (result []model.Superhero) {
+	for _, s := range cachedSuggestions {
+		superhero := model.Superhero{
+			ID:                s.ID,
+			SuperheroName:     s.SuperheroName,
+			MainProfilePicURL: s.MainProfilePicURL,
+			Gender:            s.Gender,
+			Age:               s.Age,
+			Lat:               s.Lat,
+			Lon:               s.Lon,
+			Birthday:          s.Birthday,
+			Country:           s.Country,
+			City:              s.City,
+			SuperPower:        s.SuperPower,
+			AccountType:       s.AccountType,
+			CreatedAt:         s.CreatedAt,
+		}
+
+		for _, profilePicture := range s.ProfilePictures {
+			superhero.ProfilePictures = append(superhero.ProfilePictures, model.ProfilePicture{
+				ID:                profilePicture.ID,
+				SuperheroID:       profilePicture.SuperheroID,
+				ProfilePictureURL: profilePicture.ProfilePictureURL,
+				Position:          profilePicture.Position,
+			})
+		}
+
+		result = append(result, superhero)
+	}
+
+	return result
+}
+
+// MapResultToCacheSuggestions maps API Superhero models to Cache Superhero models.
+func MapResultToCacheSuggestions(result []model.Superhero) (cacheSuggestions []cache.Superhero) {
+	for _, s := range result {
+		cacheSuggestion := cache.Superhero{
+			ID:                s.ID,
+			SuperheroName:     s.SuperheroName,
+			MainProfilePicURL: s.MainProfilePicURL,
+			Gender:            s.Gender,
+			Age:               s.Age,
+			Lat:               s.Lat,
+			Lon:               s.Lon,
+			Birthday:          s.Birthday,
+			Country:           s.Country,
+			City:              s.City,
+			SuperPower:        s.SuperPower,
+			AccountType:       s.AccountType,
+			CreatedAt:         s.CreatedAt,
+		}
+
+		for _, profilePicture := range s.ProfilePictures {
+			cacheSuggestion.ProfilePictures = append(cacheSuggestion.ProfilePictures, cache.ProfilePicture{
+				ID:                profilePicture.ID,
+				SuperheroID:       profilePicture.SuperheroID,
+				ProfilePictureURL: profilePicture.ProfilePictureURL,
+				Position:          profilePicture.Position,
+			})
+		}
+
+		cacheSuggestions = append(cacheSuggestions, cacheSuggestion)
+	}
+
+	return cacheSuggestions
+}

--- a/cmd/api/controller/service/service.go
+++ b/cmd/api/controller/service/service.go
@@ -1,0 +1,46 @@
+package service
+
+import (
+	"go.uber.org/zap"
+
+	"github.com/superhero-suggestions/internal/cache"
+	"github.com/superhero-suggestions/internal/config"
+	"github.com/superhero-suggestions/internal/es"
+)
+
+// Service holds all the different services that are used when handling request.
+type Service struct {
+	ES         *es.ES
+	Cache      *cache.Cache
+	PageSize   int
+	Logger     *zap.Logger
+	TimeFormat string
+}
+
+// NewService creates value of type Service.
+func NewService(cfg *config.Config) (*Service, error) {
+	e, err := es.NewES(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := cache.NewCache(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	logger, err := zap.NewProduction()
+	if err != nil {
+		return nil, err
+	}
+
+	defer logger.Sync()
+
+	return &Service{
+		ES:         e,
+		Cache:      c,
+		PageSize:   cfg.App.PageSize,
+		Logger:     logger,
+		TimeFormat: cfg.App.TimeFormat,
+	}, nil
+}

--- a/cmd/api/model/request.go
+++ b/cmd/api/model/request.go
@@ -2,15 +2,15 @@ package model
 
 // Request holds the parameters that are received with request at suggestions endpoint.
 type Request struct {
-	ID               string  `json:"id"`
-	LookingForGender int     `json:"lookingForGender"`
-	Gender           int     `json:"gender"`
-	LookingForAgeMin int     `json:"lookingForAgeMin"`
-	LookingForAgeMax int     `json:"lookingForAgeMax"`
-	MaxDistance      int     `json:"maxDistance"`
-	DistanceUnit     string  `json:"distanceUnit"`
-	Lat              float64 `json:"lat"`
-	Lon              float64 `json:"lon"`
-	Offset           int     `json:"offset"`
-	Size             int     `json:"size"`
+	ID               string   `json:"id"`
+	LookingForGender int      `json:"lookingForGender"`
+	Gender           int      `json:"gender"`
+	LookingForAgeMin int      `json:"lookingForAgeMin"`
+	LookingForAgeMax int      `json:"lookingForAgeMax"`
+	MaxDistance      int      `json:"maxDistance"`
+	DistanceUnit     string   `json:"distanceUnit"`
+	Lat              float64  `json:"lat"`
+	Lon              float64  `json:"lon"`
+	SuperheroIDs     []string `json:"superheroIds"`
+	IsESRequest      bool     `json:"isEsRequest"`
 }

--- a/config.yml
+++ b/config.yml
@@ -3,12 +3,14 @@ app:
   cert_file: './cmd/api/certificate.pem'
   key_file: './cmd/api/key.pem'
   time_format: '2019-09-15T14:04:05'
+  page_size: 10
 
 es:
   host: '192.168.178.17'
   port: '9200'
   cluster: superheromatch
   index: superhero
+  batch_size: 50
 
 cache:
   address: '192.168.178.17'

--- a/internal/config/app.go
+++ b/internal/config/app.go
@@ -6,4 +6,5 @@ type App struct {
 	CertFile   string `env:"APP_CERT_FILE" default:"./cmd/api/certificate.pem"`
 	KeyFile    string `env:"APP_KEY_FILE" default:"./cmd/api/key.pem"`
 	TimeFormat string `env:"APP_TIME_FORMAT" default:"2019-09-15T14:04:05"`
+	PageSize   int    `env:"APP_PAGE_SIZE" default:"10"`
 }

--- a/internal/config/es.go
+++ b/internal/config/es.go
@@ -2,8 +2,9 @@ package config
 
 // ES holds the configuration values for the Elasticsearch client.
 type ES struct {
-	Host    string `env:"ES_HOST" default:"192.168.178.26"`
-	Port    string `env:"ES_PORT" default:"9200"`
-	Cluster string `env:"ES_CLUSTER" default:"superheromatch"`
-	Index   string `env:"ES_INDEX" default:"superhero"`
+	Host      string `env:"ES_HOST" default:"192.168.178.17"`
+	Port      string `env:"ES_PORT" default:"9200"`
+	Cluster   string `env:"ES_CLUSTER" default:"superheromatch"`
+	Index     string `env:"ES_INDEX" default:"superhero"`
+	BatchSize int    `env:"ES_BATCH_SIZE" default:"50"`
 }

--- a/internal/es/es.go
+++ b/internal/es/es.go
@@ -5,16 +5,17 @@ import (
 
 	"github.com/superhero-suggestions/internal/config"
 
-	elastic "gopkg.in/olivere/elastic.v7"
+	"gopkg.in/olivere/elastic.v7"
 )
 
 // ES holds all the Elasticsearch client relevant data.
 type ES struct {
-	Client *elastic.Client
-	Host    string
-	Port    string
-	Cluster string
-	Index   string
+	Client    *elastic.Client
+	Host      string
+	Port      string
+	Cluster   string
+	Index     string
+	BatchSize int
 }
 
 // NewES creates a client connection to Elasticsearch.
@@ -33,10 +34,11 @@ func NewES(cfg *config.Config) (es *ES, err error) {
 	}
 
 	return &ES{
-		Client: client,
-		Host:    cfg.ES.Host,
-		Port:    cfg.ES.Port,
-		Cluster: cfg.ES.Cluster,
-		Index:   cfg.ES.Index,
+		Client:    client,
+		Host:      cfg.ES.Host,
+		Port:      cfg.ES.Port,
+		Cluster:   cfg.ES.Cluster,
+		Index:     cfg.ES.Index,
+		BatchSize: cfg.ES.BatchSize,
 	}, nil
 }

--- a/internal/es/model/request.go
+++ b/internal/es/model/request.go
@@ -2,15 +2,14 @@ package model
 
 // Request holds the parameters that are received with request at suggestions endpoint.
 type Request struct {
-	ID               string  `json:"id"`
-	LookingForGender int     `json:"looking_for_gender"`
-	Gender           int     `json:"gender"`
-	LookingForAgeMin int     `json:"looking_for_age_min"`
-	LookingForAgeMax int     `json:"looking_for_age_max"`
-	MaxDistance      int     `json:"max_distance"`
-	DistanceUnit     string  `json:"distance_unit"`
-	Lat              float64 `json:"lat"`
-	Lon              float64 `json:"lon"`
-	Offset           int     `json:"offset"`
-	Size             int     `json:"size"`
+	ID               string   `json:"id"`
+	LookingForGender int      `json:"looking_for_gender"`
+	Gender           int      `json:"gender"`
+	LookingForAgeMin int      `json:"looking_for_age_min"`
+	LookingForAgeMax int      `json:"looking_for_age_max"`
+	MaxDistance      int      `json:"max_distance"`
+	DistanceUnit     string   `json:"distance_unit"`
+	Lat              float64  `json:"lat"`
+	Lon              float64  `json:"lon"`
+	SuperheroIDs     []string `json:"superhero_ids"`
 }

--- a/internal/es/model/superhero.go
+++ b/internal/es/model/superhero.go
@@ -23,4 +23,5 @@ type Superhero struct {
 	City                  string           `json:"city"`
 	SuperPower            string           `json:"superpower"`
 	AccountType           string           `json:"account_type"`
+	CreatedAt             string           `json:"created_at"`
 }


### PR DESCRIPTION
This PR adds `service` package. This package holds `mappers` and abstracts all `cache` package and `elasticsearch` package methods and it is the only thing that is on `controller` struct. `Controller` then can access and call `cache` package and `elasticsearch` package methods via the `service`. This way the `controller` remains simple and clean and it doesn't have to know anything about separate packages or services.